### PR TITLE
replace absolute values with defines from atari.inc

### DIFF
--- a/drivers/atrinput.s
+++ b/drivers/atrinput.s
@@ -1,3 +1,5 @@
+.include "atari.inc"
+
 .export get_key
 .export check_for_abort_key
 .export get_key_if_available
@@ -24,7 +26,7 @@ get_key:
 ; inputs: none
 ; outputs: A contains ASCII value of key just pressed (0 if no key pressed)
 get_key_if_available:
-  lda $02fc                     ; GLOBAL VARIABLE FOR KEYBOARD
+  lda CH                        ; GLOBAL VARIABLE FOR KEYBOARD
   cmp #255
   beq @nokey
   ldx iocb                      ; K: already open?
@@ -32,23 +34,23 @@ get_key_if_available:
   ldx #$40                      ; IOCB to use for keyboard input
   stx iocb                      ; mark K: as open
   lda #<kname
-  sta $344,x                    ; 1-byte low buffer address
+  sta ICBAL,x                   ; 1-byte low buffer address
   lda #>kname
-  sta $345,x                    ; 1-byte high buffer address
-  lda #3                        ; open
-  sta $342,x                    ; COMMAND CODE
-  lda #4                        ; open for input (all devices)
-  sta $34a,x                    ; 1-byte first auxiliary information
-  jsr $e456                     ; vector to CIO
+  sta ICBAH,x                   ; 1-byte high buffer address
+  lda #OPEN                     ; open
+  sta ICCOM,x                   ; COMMAND CODE
+  lda #OPNIN                    ; open for input (all devices)
+  sta ICAX1,x                   ; 1-byte first auxiliary information
+  jsr CIOV                      ; vector to CIO
 @read:
   lda #0
-  sta $348,x                    ; 1-byte low buffer length
-  sta $349,x                    ; 1-byte high buffer length
-  lda #7                        ; get character(s)
-  sta $342,x                    ; COMMAND CODE
-  jsr $e456                     ; vector to CIO
+  sta ICBLL,x                   ; 1-byte low buffer length
+  sta ICBLH,x                   ; 1-byte high buffer length
+  lda #GETCHR                   ; get character(s)
+  sta ICCOM,x                   ; COMMAND CODE
+  jsr CIOV                      ; vector to CIO
   ldx #255
-  stx $02fc                     ; GLOBAL VARIABLE FOR KEYBOARD
+  stx CH                        ; GLOBAL VARIABLE FOR KEYBOARD
   rts
 @nokey:
   lda #0

--- a/drivers/atrprint.s
+++ b/drivers/atrprint.s
@@ -1,3 +1,4 @@
+.include "atari.inc"
 .include "../inc/common.i"
 
 .export print_a
@@ -5,11 +6,6 @@
 .export print_cr
 .export cls
 .export beep
-.exportzp screen_current_row
-.exportzp screen_current_col
-
-screen_current_col = $55        ; 2-byte cursor column
-screen_current_row = $54        ; 1-byte cursor row
 
 
 .bss
@@ -25,11 +21,11 @@ char: .res 1
 print_a:
   cmp #10                       ; is it a CR?
   bne @not_lf
-  lda #155                      ; CR/LF char
+  lda #ATEOL                    ; CR/LF char
 @not_lf:
   cmp #13                       ; is it a LF?
   bne @not_cr
-  lda #155                      ; CR/LF char
+  lda #ATEOL                    ; CR/LF char
 @not_cr:
   sta char
   txa
@@ -37,13 +33,13 @@ print_a:
   tya
   pha
   ldax #1
-  stax $0348                    ; 2-byte buffer length
+  stax ICBLL                    ; 2-byte buffer length
   ldax #char
-  stax $0344                    ; 2-byte buffer address
-  ldx #11                       ; put character(s)
-  stx $0342                     ; COMMAND CODE
-  ldx #0
-  jsr $e456                     ; vector to CIO
+  stax ICBAL                    ; 2-byte buffer address
+  ldx #PUTCHR                   ; put character(s)
+  stx ICCOM                     ; COMMAND CODE
+  ldx #0                        ; use IOCB #0
+  jsr CIOV                      ; vector to CIO
   pla
   tay
   pla
@@ -54,21 +50,21 @@ print_a:
 ; inputs: none
 ; outputs: none
 print_cr:
-  lda #155                      ; CR/LF char
+  lda #ATEOL                    ; CR/LF char
   jmp print_a
 
 ; use ATARI CIOV function to clear the screen
 ; inputs: none
 ; outputs: none  
 cls:
-  lda #125                      ; clear screen
+  lda #ATCLR                    ; clear screen
   jmp print_a
 
 ; use ATARI CIOV function to make a 'beep' noise
 ; inputs: none
 ; outputs: none
 beep:
-  lda #253                      ; beep char
+  lda #ATBEL                    ; beep char
   jmp print_a
 
 print_a_inverse:

--- a/drivers/atrtimer.s
+++ b/drivers/atrtimer.s
@@ -4,6 +4,7 @@
 ; 1000 units per second. it doesn't have to be particularly accurate.
 ; this Atari implementation requires the routine timer_vbl_handler be called 60 times per second
 
+.include "atari.inc"
 .include "../inc/common.i"
 
 .export timer_init
@@ -32,12 +33,12 @@ vbichain: .word 0
 timer_init:
   lda vbichain+1
   bne @handler_installed
-  ldax $222                     ; IMMEDIATE VERTICAL BLANK NMI VECTOR
+  ldax VVBLKI                   ; IMMEDIATE VERTICAL BLANK NMI VECTOR
   stax vbichain                 ; save old immediate vector
   ldy #<timer_vbl_handler
   ldx #>timer_vbl_handler
   lda #6                        ; STAGE 1 VBI
-  jsr $e45c                     ; vector to set VBLANK parameters
+  jsr SETVBV                    ; vector to set VBLANK parameters
 @handler_installed:
   lda #0
   sta current_time_value
@@ -52,7 +53,7 @@ timer_exit:
   ldy vbichain
   ldx vbichain+1
   lda #6                        ; STAGE 1 VBI
-  jsr $e45c                     ; vector to set VBLANK parameters
+  jsr SETVBV                    ; vector to set VBLANK parameters
 @handler_not_installed:
   rts
 
@@ -104,7 +105,7 @@ timer_vbl_handler:
 : sta current_seconds
 @done:
   pla
-  jmp $e45f                     ; vector to process immediate VBLANK
+  jmp SYSVBV                    ; vector to process immediate VBLANK
 
 timer_seconds:
   lda current_seconds


### PR DESCRIPTION
Mechanical replacement of absolute values. The compiled test programs are identical to versions before this change.